### PR TITLE
Ensure service call errors are handled

### DIFF
--- a/lib/sso.js
+++ b/lib/sso.js
@@ -11,7 +11,7 @@ if (!SAML_SERVICE || SAML_SERVICE === '') {
 var router = new express.Router();
 router.use(bodyParser());
 
-router.post('/session/login_host', function(req, res) {
+router.post('/session/login_host', function(req, res, next) {
   // Fetch the MBaaS SSO Service Host for the Client to use
   fh.service({
     "guid": SAML_SERVICE,
@@ -22,8 +22,10 @@ router.post('/session/login_host', function(req, res) {
     }
   }, function(err, body, service_res) {
     if (err) {
-      // An error occurred 
+      // An error occurred
       console.log('Service call failed: ', err, service_res);
+      
+      next(err);
     } else {
       res.json({
         "sso": body.host
@@ -32,7 +34,7 @@ router.post('/session/login_host', function(req, res) {
   });
 });
 
-router.post('/session/valid', function(req, res) {
+router.post('/session/valid', function(req, res, next) {
   console.log('/session/valid', req.body);
   // As the SSO Service if this device has a current session
   fh.service({
@@ -45,8 +47,10 @@ router.post('/session/valid', function(req, res) {
   }, function(err, body, service_res) {
     console.log('call', body, service_res);
     if (err) {
-      // An error occurred 
-      console.log('Service call failed: ', err);
+      // An error occurred
+      console.log('Service call failed: ', err, service_res);
+
+      next(err);
     } else {
       res.json(body);
     }


### PR DESCRIPTION
Previously errors were logged but no response was sent to the calling client. This fixes that by using the default error handler.
