### PR TITLE
Replace turbo with mocha

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -93,9 +93,7 @@ module.exports = function(grunt) {
         },
         command: [
           'rm -rf coverage cov-unit',
-          'env NODE_PATH=. ./node_modules/.bin/istanbul cover --dir cov-unit ./node_modules/.bin/turbo -- test/unit',
-          './node_modules/.bin/istanbul report',
-          'echo "See html coverage at: `pwd`/coverage/lcov-report/index.html"'
+          'env NODE_PATH=. ./node_modules/.bin/istanbul cover --dir cov-unit ./node_modules/.bin/_mocha -- -u exports -R spec ./test/unit/*.js'
         ].join('&&')
       },
       coverage_accept: {
@@ -105,9 +103,7 @@ module.exports = function(grunt) {
         },
         command: [
           'rm -rf coverage cov-accept',
-          'env NODE_PATH=. ./node_modules/.bin/istanbul cover --dir cov-accept ./node_modules/.bin/turbo -- --setUp=test/accept/server.js --tearDown=test/accept/server.js test/accept',
-          './node_modules/.bin/istanbul report',
-          'echo "See html coverage at: `pwd`/coverage/lcov-report/index.html"'
+          'env NODE_PATH=. ./node_modules/.bin/istanbul cover --dir cov-accept ./node_modules/.bin/_mocha -- -u exports -R spec ./test/server.js ./test/accept/*.js'
         ].join('&&')
       }
     },

--- a/README.md
+++ b/README.md
@@ -44,3 +44,19 @@ Session check endpoint
     + Body
             {
             }
+
+## Tests
+
+All the tests are in the "test/" directory. The cloud app is using mocha as the test runner. 
+
+### Unit and acceptance tests
+
+```shell
+npm test
+```
+
+### Code coverage
+
+```shell
+npm run coverage
+```

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "fh-mbaas-api": "~6.1.7"
   },
   "devDependencies": {
-    "mocha": "^2.1.0",
+    "grunt": "^0.4.0",
     "grunt-concurrent": "latest",
     "grunt-contrib-jshint": "^0.11.3",
     "grunt-contrib-watch": "latest",
@@ -21,6 +21,7 @@
     "grunt-shell": "^0.7.0",
     "istanbul": "0.2.7",
     "load-grunt-tasks": "^0.4.0",
+    "mocha": "^2.1.0",
     "proxyquire": "0.5.3",
     "should": "2.1.1",
     "sinon": "^1.17.2",
@@ -29,7 +30,8 @@
   },
   "main": "application.js",
   "scripts": {
-    "test": "grunt unit",
+    "test": "grunt test",
+    "coverage": "grunt coverage",
     "debug": "grunt serve",
     "start": "node application.js"
   },


### PR DESCRIPTION
# Motivation
https://issues.jboss.org/browse/RHMAP-14685

# Changes
- replaced turbo with mocha for code coverage
- added grunt to dev-dependencies (needed with npm version >=3)

# Steps to verify
- `npm install`
- then these commands should work:
  - `grunt serve`
  - `grunt test`
  - `grunt coverage`